### PR TITLE
QC-14566: Renamed the liveState event listener for livestatechange

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Events you can listen to:
 | `closedcaptionslanguagechange` | Triggered when the closed captions language is updated |
 | `ended`                        | Triggered when the playback ends                       |
 | `layoutchange`                 | Triggered when the layout changes                      |
-| `liveState`                    | Triggered when the state of a live event changes       |
+| `livestatechange`              | Triggered when the state of a live event changes       |
 | `pause`                        | Triggered when the playback pauses                     |
 | `play`                         | Triggered when the playback resumes                    |
 | `playbackratechange`           | Triggered when the playback rate changes               |

--- a/docs/content/posts/demos/live.mdx
+++ b/docs/content/posts/demos/live.mdx
@@ -13,7 +13,7 @@ import { IFRAME_URL } from '../../../variables';
     <PlaygroundButton type="get" command="getLiveStartTime">Get start time of live event</PlaygroundButton>
     <PlaygroundButton type="get" command="getLiveEndTime">Get end time of live event</PlaygroundButton>
     <hr/>
-    <PlaygroundCheckbox id="addEventListener" checked={true} event="liveState">Listen for `liveState` events</PlaygroundCheckbox>
+    <PlaygroundCheckbox id="addEventListener" checked={true} event="livestatechange">Listen for `livestatechange` events</PlaygroundCheckbox>
   </div>
   <div slot="code">
     ```js
@@ -43,8 +43,8 @@ import { IFRAME_URL } from '../../../variables';
         });
     });
 
-    sdk.addEventListener('liveState', (newLiveState) => {
-      console.log('liveState', newLiveState);
+    sdk.addEventListener('livestatechange', (newLiveState) => {
+      console.log('livestatechange', newLiveState);
     });
     ```
   </div>

--- a/src/models/internal.ts
+++ b/src/models/internal.ts
@@ -3,7 +3,7 @@ type SdkEventListener =
   | 'closedcaptionslanguagechange'
   | 'ended'
   | 'layoutchange'
-  | 'liveState'
+  | 'livestatechange'
   | 'pause'
   | 'play'
   | 'playbackratechange'

--- a/src/services/test/player-sdk.service.spec.ts
+++ b/src/services/test/player-sdk.service.spec.ts
@@ -260,13 +260,13 @@ describe('Service', () => {
       });
     });
 
-    describe('liveState', () => {
+    describe('livestatechange', () => {
       it('should listen to events', async () => {
         expect.assertions(1);
 
         const sdk = initSdk();
 
-        sdk.addEventListener('liveState', (state: number) => {
+        sdk.addEventListener('livestatechange', (state: number) => {
           expect(state).toEqual('LIVE');
         });
 
@@ -276,7 +276,7 @@ describe('Service', () => {
         postMessageFromPlayer({
           action: 'event',
           guid,
-          name: 'liveState',
+          name: 'livestatechange',
           value: 'LIVE',
         } as SdkEventMessage);
       });


### PR DESCRIPTION
This PR RenameS the `liveState` event listener for `livestatechange`.