### PR TITLE
QC-14580: Improved the API functions around chapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ Sets the current caption track.
 
 Gets the available caption tracks.
 
-### getChapter(): Promise&lt;Chapter%gt;
-
-Gets the current chapter.
-
 ### getChapters(): Promise&lt;Chapter[]&gt;
 
 Gets the list of chapters for the presentation.
+
+### getCurrentChapter(): Promise&lt;Chapter%gt;
+
+Gets the current chapter.
 
 ### getCurrentCaptionTrack(): Promise&lt;SdkCaptionTrack&gt;
 
@@ -136,7 +136,7 @@ Gets the position of the PiP box.
 
 ### getPlaybackRate(): Promise&lt;number&gt;
 
-Gets the current playback rate.
+Gets the playback rate.
 
 ### getPlaybackRates(): Promise&lt;number&gt;
 

--- a/docs/content/posts/demos/chapters.mdx
+++ b/docs/content/posts/demos/chapters.mdx
@@ -10,7 +10,7 @@ import { IFRAME_URL } from '../../../variables';
 <Playground url={IFRAME_URL}>
   <div slot="actions" className="actions">
     <PlaygroundButton type="get" command="getChapters">Get chapters list</PlaygroundButton>
-    <PlaygroundButton type="get" command="getChapter">Get current chapter</PlaygroundButton>
+    <PlaygroundButton type="get" command="getCurrentChapter">Get current chapter</PlaygroundButton>
     <hr/>
     <PlaygroundCheckbox id="addEventListener" checked={true} event="chapterchange">Listen for `chapterchange` events</PlaygroundCheckbox>
   </div>
@@ -28,8 +28,8 @@ import { IFRAME_URL } from '../../../variables';
         });
     });
 
-    document.getElementById('getChapter').addEventListener('click', () => {
-      sdk.getChapter()
+    document.getElementById('getCurrentChapter').addEventListener('click', () => {
+      sdk.getCurrentChapter()
         .then((chapter) => {
           console.log('current chapter', chapter)
         });

--- a/docs/content/posts/usage.mdx
+++ b/docs/content/posts/usage.mdx
@@ -46,13 +46,13 @@ Sets the current caption track.
 
 Gets the available caption tracks.
 
-## getChapter(): Promise&lt;Chapter%gt;
-
-Gets the current chapter.
-
 ## getChapters(): Promise&lt;Chapter[]&gt;
 
 Gets the list of chapters for the presentation.
+
+### getCurrentChapter(): Promise&lt;Chapter%gt;
+
+Gets the current chapter.
 
 ## getCurrentCaptionTrack(): Promise&lt;SdkCaptionTrack&gt;
 
@@ -88,7 +88,7 @@ Gets the position of the PiP box.
 
 ## getPlaybackRate(): Promise&lt;number&gt;
 
-Gets the current playback rate.
+Gets the playback rate.
 
 ## getPlaybackRates(): Promise&lt;number&gt;
 

--- a/src/services/player-sdk.service.ts
+++ b/src/services/player-sdk.service.ts
@@ -159,17 +159,17 @@ export class PlayerSdk {
   }
 
   /**
-   * Gets the chapter
-   */
-  async getChapter(): Promise<any> {
-    return this.get('chapter');
-  }
-
-  /**
    * Gets the list of chapters for the presentation
    */
   async getChapters(): Promise<any[]> {
     return this.get('chapters');
+  }
+
+  /**
+   * Gets the current chapter
+   */
+  async getCurrentChapter(): Promise<any> {
+    return this.get('chapter');
   }
 
   /**
@@ -215,7 +215,7 @@ export class PlayerSdk {
   }
 
   /**
-   * Gets the presentation's live state
+   * Gets the state of a live event
    */
   async getLiveState(): Promise<string | null> {
     return this.get('liveState');
@@ -229,7 +229,7 @@ export class PlayerSdk {
   }
 
   /**
-   * Gets the current playback rate
+   * Gets the playback rate
    */
   async getPlaybackRate(): Promise<number> {
     return this.get('playbackRate');

--- a/src/services/test/player-sdk.service.spec.ts
+++ b/src/services/test/player-sdk.service.spec.ts
@@ -554,60 +554,6 @@ describe('Service', () => {
     });
   });
 
-  describe('getChapter', () => {
-    it('should send the appropriate message to the iframe', async () => {
-      const spy = jest.spyOn(iframe.contentWindow as any, 'postMessage');
-      const sdk = initSdk();
-
-      sdk.getChapter();
-
-      // we need to wait for a tick to get the code inside the promise to be executed
-      await nextTick();
-
-      expect(spy).toHaveBeenCalledWith(
-        JSON.stringify({
-          action: 'get',
-          guid,
-          name: 'chapter',
-          version: 3,
-        }),
-        url.origin,
-      );
-    });
-
-    it('should return the value from the iframe', async () => {
-      expect.assertions(1);
-
-      const chapter = {
-        guid: 'chapter1',
-        hidden: false,
-        image: {
-          guid: 'image1',
-          url: 'http://example.com/image1.jpg',
-        },
-        time: 1000,
-        title: 'foo',
-      };
-
-      const sdk = initSdk();
-
-      sdk.getChapter()
-        .then((c) => {
-          expect(c).toEqual(chapter);
-        });
-
-      // we need to wait for a tick to get the code inside the promise to be executed
-      await nextTick();
-
-      postMessageFromPlayer({
-        action: 'get',
-        guid,
-        name: 'chapter',
-        value: chapter,
-      } as SdkGetSetMessage);
-    });
-  });
-
   describe('getChapters', () => {
     it('should send the appropriate message to the iframe', async () => {
       const spy = jest.spyOn(iframe.contentWindow as any, 'postMessage');
@@ -670,6 +616,60 @@ describe('Service', () => {
         guid,
         name: 'chapters',
         value: chapters,
+      } as SdkGetSetMessage);
+    });
+  });
+
+  describe('getCurrentChapter', () => {
+    it('should send the appropriate message to the iframe', async () => {
+      const spy = jest.spyOn(iframe.contentWindow as any, 'postMessage');
+      const sdk = initSdk();
+
+      sdk.getCurrentChapter();
+
+      // we need to wait for a tick to get the code inside the promise to be executed
+      await nextTick();
+
+      expect(spy).toHaveBeenCalledWith(
+        JSON.stringify({
+          action: 'get',
+          guid,
+          name: 'chapter',
+          version: 3,
+        }),
+        url.origin,
+      );
+    });
+
+    it('should return the value from the iframe', async () => {
+      expect.assertions(1);
+
+      const chapter = {
+        guid: 'chapter1',
+        hidden: false,
+        image: {
+          guid: 'image1',
+          url: 'http://example.com/image1.jpg',
+        },
+        time: 1000,
+        title: 'foo',
+      };
+
+      const sdk = initSdk();
+
+      sdk.getCurrentChapter()
+        .then((c) => {
+          expect(c).toEqual(chapter);
+        });
+
+      // we need to wait for a tick to get the code inside the promise to be executed
+      await nextTick();
+
+      postMessageFromPlayer({
+        action: 'get',
+        guid,
+        name: 'chapter',
+        value: chapter,
       } as SdkGetSetMessage);
     });
   });
@@ -765,6 +765,49 @@ describe('Service', () => {
         action: 'get',
         guid,
         name: 'currentTime',
+        value: 1000,
+      } as SdkGetSetMessage);
+    });
+  });
+
+  describe('getDuration', () => {
+    it('should send the appropriate message to the iframe', async () => {
+      const spy = jest.spyOn(iframe.contentWindow as any, 'postMessage');
+      const sdk = initSdk();
+
+      sdk.getDuration();
+
+      // we need to wait for a tick to get the code inside the promise to be executed
+      await nextTick();
+
+      expect(spy).toHaveBeenCalledWith(
+        JSON.stringify({
+          action: 'get',
+          guid,
+          name: 'duration',
+          version: 3,
+        }),
+        url.origin,
+      );
+    });
+
+    it('should return the value from the iframe', async () => {
+      expect.assertions(1);
+
+      const sdk = initSdk();
+
+      sdk.getDuration()
+        .then((duration) => {
+          expect(duration).toEqual(1000);
+        });
+
+      // we need to wait for a tick to get the code inside the promise to be executed
+      await nextTick();
+
+      postMessageFromPlayer({
+        action: 'get',
+        guid,
+        name: 'duration',
         value: 1000,
       } as SdkGetSetMessage);
     });
@@ -895,49 +938,6 @@ describe('Service', () => {
         guid,
         name: 'liveState',
         value: 'LIVE',
-      } as SdkGetSetMessage);
-    });
-  });
-
-  describe('getDuration', () => {
-    it('should send the appropriate message to the iframe', async () => {
-      const spy = jest.spyOn(iframe.contentWindow as any, 'postMessage');
-      const sdk = initSdk();
-
-      sdk.getDuration();
-
-      // we need to wait for a tick to get the code inside the promise to be executed
-      await nextTick();
-
-      expect(spy).toHaveBeenCalledWith(
-        JSON.stringify({
-          action: 'get',
-          guid,
-          name: 'duration',
-          version: 3,
-        }),
-        url.origin,
-      );
-    });
-
-    it('should return the value from the iframe', async () => {
-      expect.assertions(1);
-
-      const sdk = initSdk();
-
-      sdk.getDuration()
-        .then((duration) => {
-          expect(duration).toEqual(1000);
-        });
-
-      // we need to wait for a tick to get the code inside the promise to be executed
-      await nextTick();
-
-      postMessageFromPlayer({
-        action: 'get',
-        guid,
-        name: 'duration',
-        value: 1000,
       } as SdkGetSetMessage);
     });
   });


### PR DESCRIPTION
Rename `getChapter()` for `getCurrentChapter()`.

I do not see any other method worth of being renamed but I am open to suggestions.