### PR TITLE
QENG-555: Fix umd exposed name to match the docs

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -17,9 +17,9 @@
     "dist/"
   ],
   "scripts": {
-    "build": "microbundle",
-    "dev": "microbundle",
-    "dev:watch": "microbundle watch",
+    "build": "microbundle --name playerSdk",
+    "dev": "microbundle --name playerSdk",
+    "dev:watch": "microbundle watch --name playerSdk",
     "prepublishOnly": "node scripts/prepublishOnly.js",
     "test": "jest",
     "test:cov": "jest --coverage",


### PR DESCRIPTION
After migrating to workspaces the exported name of the umd bundle was changed to the package name `lib` automatically, which has broken the examples in the docs. This PR switches back to the initial name `playerSdk`.

Test 1
- run `npm run build`
- create a html page and include umd bundle script `dist/index.umd.js`
- open the page and verify the sdk was placed in the `window.playerSdk.PlayerSdk`