### PR TITLE
Fix URL from migration.mdx to installation

### DIFF
--- a/packages/docs/src/content/docs/legacy/migration.mdx
+++ b/packages/docs/src/content/docs/legacy/migration.mdx
@@ -6,7 +6,7 @@ title: "Migration"
 
 ### Load the new SDK
 
-Please follow <a href={`${import.meta.env.BASE_URL}installation`}>the installation page</a>
+Please follow <a href={`${import.meta.env.BASE_URL}/guides/installation/`}>the installation page</a>
 to load the new SDK
 
 ### `.init()` is removed


### PR DESCRIPTION
Links to https://qumu.github.io/player-sdkinstallation which gives a 404 because of the missing slash and guides, as it probably should link to https://qumu.github.io/player-sdk/guides/installation/