### PR TITLE
QENG-4243: fix types declaration path

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -11,7 +11,8 @@
   "module": "./dist/index.module.js",
   "exports": {
     "require": "./dist/index.js",
-    "default": "./dist/index.modern.mjs"
+    "default": "./dist/index.modern.mjs",
+    "types": "./dist/index.d.ts"
   },
   "files": [
     "dist/"


### PR DESCRIPTION
Fixes path for exporting index.d.ts file so TypeScript can find it