### PR TITLE
QENG-4243: handle escaped characters in url and iframe's src matching

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,7 +10,7 @@ jobs:
     name: Create new release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
@@ -29,13 +29,13 @@ jobs:
     name: Release package to NPM
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
 
       - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'npm'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,13 +13,13 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
 
       - name: Use Node.js 18
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: 'npm'

--- a/packages/lib/src/services/player-sdk.service.ts
+++ b/packages/lib/src/services/player-sdk.service.ts
@@ -62,9 +62,7 @@ export class PlayerSdk {
         }
 
         if (message?.action === 'ready') {
-          const frame = message.value
-            ? window.document.querySelector(`iframe[src="${message.value}"]`) as HTMLIFrameElement
-            : this.iframe;
+          const frame = this.findIframe(message.value);
 
           if (!frame) {
             // eslint-disable-next-line no-console
@@ -508,6 +506,35 @@ export class PlayerSdk {
     }
 
     this.postMessage(message);
+  }
+
+  /**
+   * Finds the iframe in the document matching the url
+   */
+  private findIframe(url?: string): HTMLIFrameElement | undefined {
+    if (!url) {
+      return this.iframe;
+    }
+
+    const iframeMatching = window.document.querySelector(`iframe[src="${url}"]`) as HTMLIFrameElement;
+
+    if (iframeMatching) {
+      return iframeMatching;
+    }
+
+    // In case url from the message contains non encoded characters
+    // while iframe's src contains encoded characters then we need to decode them
+    // for example `<iframe src="https://example.com?abc%7E1"></iframe>` will result in
+    // url being `https://example.com?abc~1`
+    const iframes = window.document.querySelectorAll('iframe');
+
+    const decodedUrl = decodeURIComponent(url);
+
+    for (const iframe of iframes) {
+      if (decodedUrl === decodeURIComponent(iframe.src)) {
+        return iframe;
+      }
+    }
   }
 
   /**

--- a/packages/lib/src/services/test/player-sdk.service.spec.ts
+++ b/packages/lib/src/services/test/player-sdk.service.spec.ts
@@ -457,6 +457,26 @@ describe('Service', () => {
 
         expect(callback).not.toHaveBeenCalled();
       });
+
+      it('should match escaped and unescaped URLs', async () => {
+        expect.assertions(1);
+
+        iframe.src = 'https://knowledge.qumucloud.com/view/sample-id?abc%7E1';
+        const callback = jest.fn();
+
+        const sdk = new PlayerSdk(iframe);
+
+        sdk.addEventListener('ready', callback);
+
+        postMessageFromPlayer<SdkReadyMessage>({
+          action: 'ready',
+          value: 'https://knowledge.qumucloud.com/view/sample-id?abc~1',
+        });
+
+        await Promise.resolve();
+
+        expect(callback).toHaveBeenCalled();
+      });
     });
 
     describe('timeupdate', () => {

--- a/packages/lib/src/services/test/player-sdk.service.spec.ts
+++ b/packages/lib/src/services/test/player-sdk.service.spec.ts
@@ -118,6 +118,26 @@ describe('Service', () => {
         'https://knowledge.qumucloud.com/view/efgh5678',
       );
     });
+
+    it('should match escaped and unescaped URLs', async () => {
+      expect.assertions(1);
+
+      iframe.src = 'https://knowledge.qumucloud.com/view/sample-id?abc%7E1';
+      const callback = jest.fn();
+
+      const sdk = new PlayerSdk(iframe);
+
+      sdk.addEventListener('ready', callback);
+
+      postMessageFromPlayer<SdkReadyMessage>({
+        action: 'ready',
+        value: 'https://knowledge.qumucloud.com/view/sample-id?abc~1',
+      });
+
+      await Promise.resolve();
+
+      expect(callback).toHaveBeenCalled();
+    });
   });
 
   describe('addEventListener', () => {
@@ -456,26 +476,6 @@ describe('Service', () => {
         await Promise.resolve();
 
         expect(callback).not.toHaveBeenCalled();
-      });
-
-      it('should match escaped and unescaped URLs', async () => {
-        expect.assertions(1);
-
-        iframe.src = 'https://knowledge.qumucloud.com/view/sample-id?abc%7E1';
-        const callback = jest.fn();
-
-        const sdk = new PlayerSdk(iframe);
-
-        sdk.addEventListener('ready', callback);
-
-        postMessageFromPlayer<SdkReadyMessage>({
-          action: 'ready',
-          value: 'https://knowledge.qumucloud.com/view/sample-id?abc~1',
-        });
-
-        await Promise.resolve();
-
-        expect(callback).toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
Handle matching iframe's src and URL from the player not matching on escaped characters (like `~` being `%7E`)