### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,4 +1,6 @@
 name: "Generate release & new package to NPM"
+permissions:
+  contents: read
 
 on:
   push:
@@ -8,6 +10,8 @@ on:
 jobs:
   create-release:
     name: Create new release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/qumu/player-sdk/security/code-scanning/4](https://github.com/qumu/player-sdk/security/code-scanning/4)

To address the lack of an explicit permissions block, add a `permissions` statement to the relevant scope(s) in your workflow. As a best-practice minimal starting point, set `permissions: contents: read` at the top (`root`) of the workflow. This restricts the default token access for all jobs. For any job (such as `create-release`) that requires additional permission (e.g. to create a release on GitHub), customize its job section with the necessary `permissions` (e.g. `contents: write`). Place the root-level `permissions` block just below the workflow `name`. For `publish-package`, leave the default of `contents: read` unless you find it needs more in the future.

**What to change:**  
- Add root-level `permissions: contents: read` just after the `name:` in `.github/workflows/package.yml`.
- Add an explicit `permissions: contents: write` block to the `create-release` job, so its `GITHUB_TOKEN` can create releases.
- `publish-package` remains at `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
