### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,6 @@
 name: "Lint, test and scan"
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/qumu/player-sdk/security/code-scanning/3](https://github.com/qumu/player-sdk/security/code-scanning/3)

To fix the problem, a `permissions` block with the least required privileges should be added. Since all visible steps in the job perform read-only actions (checking out code, installing dependencies, linting, testing, scanning with SonarCloud using its own token), the minimal required permission is `contents: read`. The best and simplest fix is to add a `permissions: contents: read` block either at the root of the workflow (below the name/on blocks) or directly under the `unit-test` job. Both approaches are functionally equivalent here since only one job is present, but typically the root permissions block is recommended as a sensible default. 

Specifically, add the following to the workflow file, .github/workflows/pull-request.yml:
- Insert 
  ```
  permissions:
    contents: read
  ```
  after the `name:` field and before the `on:` field for root-level scoping.

No other methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
