### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   github-pages:
     name: Deploy to Github Pages
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/qumu/player-sdk/security/code-scanning/1](https://github.com/qumu/player-sdk/security/code-scanning/1)

To resolve the issue, an explicit `permissions` block should be added to the job executing the deployment (`github-pages`). This block should grant only the minimal required permissions for each step. For the `peaceiris/actions-gh-pages@v3.9.2` action to deploy to GitHub Pages, `contents: write` is required. If no other steps require special permissions, `contents: write` alone is sufficient as a minimal starting point. 

Edit the `.github/workflows/github-pages.yml` file by adding:
```yaml
permissions:
  contents: write
```
either at the workflow root (to affect all jobs), or inside the `github-pages` job definition. In this case, since there's only one job, both are equivalent, but it's more precise to add it at the job level (lines 13-14), directly beneath `name: Deploy to Github Pages`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
