### PR TITLE
Potential fix for code scanning alert no. 6: Checkout of untrusted code in trusted context

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.ref }}
 
       - name: Create Release
         uses: actions/github-script@v6.1.0
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.ref }}
 
       - name: Use Node.js 18
         uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/qumu/player-sdk/security/code-scanning/6](https://github.com/qumu/player-sdk/security/code-scanning/6)

To fix the potential vulnerability, the workflow should ensure it only checks out the trusted, signed tag that triggered the workflow, rather than dynamically referencing any possibly untrusted ref (like `${{ github.head_ref }}`). In this context, replace `ref: ${{ github.head_ref }}` with `ref: ${{ github.ref }}`, which points directly to the tag ref that triggered the workflow. This change should be made in both jobs where actions/checkout occurs. No other changes are necessary. After this modification, the workflow will only operate on trusted code corresponding to the release tag.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
